### PR TITLE
Add an option for a quasi-static model

### DIFF
--- a/data/settings_ram.yaml
+++ b/data/settings_ram.yaml
@@ -35,6 +35,7 @@ kite:
     bridle_fracs: [0.088, 0.31, 0.58, 0.93] # distances along normalized foil chord for bridle attachment points
     fixed_index: 1                          # the bridle frac index around which the kite twists
     mass: 0.9                               # kite mass [kg]
+    quasi_static: false                     # whether to use quasi static kite points or not
 
 tether:
     bridle_tether_diameter: 2 # [mm]

--- a/examples/ram_air_kite_loop.jl
+++ b/examples/ram_air_kite_loop.jl
@@ -8,15 +8,16 @@ end
 include("./plotting.jl")
 
 dt = 0.05
-total_time = 4.5
+total_time = 3.5
 vsm_interval = 5
 steps = Int(round(total_time / dt))
 
 set = se("system_ram.yaml")
 set.segments = 2
 set_values = [-50, -1.1, -1.1]
+set.quasi_static = true
 
-if !@isdefined s
+# if !@isdefined s
     wing = RamAirWing(set)
     aero = BodyAerodynamics([wing])
     vsm_solver = Solver(aero; solver_type=NONLIN, atol=1e-8, rtol=1e-8)
@@ -24,20 +25,23 @@ if !@isdefined s
     s = RamAirKite(set, aero, vsm_solver, point_system)
 
     measure = Measurement()
-end
+# end
 s.set.abs_tol = 1e-5
 s.set.rel_tol = 1e-3
 
+measure.sphere_pos .= deg2rad.([50.0 50.0; 1.0 -1.0])
 if !ispath(joinpath(get_data_path(), "prob.bin"))
     KiteModels.init_sim!(s, measure)
 end
-measure.sphere_pos .= deg2rad.([50.0 50.0; 1.0 -1.0])
-@time KiteModels.reinit!(s, measure)
+@time KiteModels.reinit!(s, measure; reload=true)
+sys = s.sys
+s.integrator.ps[sys.steady] = true
+next_step!(s; dt=10.0, vsm_interval=1)
+s.integrator.ps[sys.steady] = false
 
 logger = Logger(length(s.point_system.points), steps)
 
 sys_state = KiteModels.SysState(s)
-sys = s.sys
 l = s.set.l_tether + 10
 t = 0.
 runtime = 0.
@@ -45,10 +49,11 @@ integ_runtime = 0.
 try
     while t < total_time
         global t, runtime, integ_runtime
-        PLOT && plot(s, t; zoom=false, front=false)
+        PLOT && plot(s, t; zoom=true, front=false)
         global set_values = -s.set.drum_radius .* s.integrator[sys.winch_force]
-        if (t < 3.0); set_values -= [0, 0, 5]; end
+        if (t < 2.0); set_values -= [0, 0, 5]; end
         steptime = @elapsed (t, integ_steptime) = next_step!(s, set_values; dt, vsm_interval)
+        t -= 10.0
         if (t > total_time/2); runtime += steptime; end
         if (t > total_time/2); integ_runtime += integ_steptime; end
         KiteModels.update_sys_state!(sys_state, s)
@@ -68,6 +73,9 @@ try
         sys_state.var_11 = s.integrator[sys.twist_angle[3]]
         sys_state.var_12 = s.integrator[sys.twist_angle[4]]
 
+        sys_state.var_13 = clamp(s.integrator[sys.pulley_acc[1]], -100, 100)
+        sys_state.var_14 = clamp(s.integrator[sys.pulley_acc[2]], -100, 100)
+
         log!(logger, sys_state)
     end
 catch e
@@ -83,14 +91,16 @@ p=plotx(logger.time_vec,
         [logger.var_04_vec, logger.var_05_vec],
         [logger.var_06_vec, logger.var_07_vec, logger.var_08_vec],
         [logger.var_09_vec, logger.var_10_vec, logger.var_11_vec, logger.var_12_vec],
+        [logger.var_13_vec, logger.var_14_vec],
         [logger.heading_vec]
         ;
-    ylabels=["kite", "tether", "vsm", "twist", "heading"], 
+    ylabels=["kite", "tether", "vsm", "twist", "pulley", "heading"], 
     labels=[
         ["ω_b[1]", "ω_b[2]", "ω_b[3]"],
         ["vel[1]", "vel[2]"],
         ["force[3]", "kite moment[2]", "group moment[1]"],
-        ["twist_angle[1]", "twist_angle[2]", "twist_angle[3]", "twist_angle[4]"],
+        ["twist_alpha[1]", "twist_alpha[2]", "twist_alpha[3]", "twist_alpha[4]"],
+        ["pulley acc[1]", "pulley acc[2]"],
         ["heading"]
         ],
     fig="Steering and heading MTK model")
@@ -98,5 +108,14 @@ display(p)
 
 println("Times realtime: ", (total_time/2) / runtime)
 println("Times realtime, just integrator: ", (total_time/2) / integ_runtime)
+
+@show norm(logger.var_13_vec[steps÷2:end])
+
+# diffs = [norm(diff([u[i] for u in s.integrator.sol.u[1000:end]])) for i in eachindex(s.integrator.u)]
+# names = unknowns(s.prob.f.sys)
+# for (n, d) in zip(names, diffs)
+#     println(round(d; digits=2), "\t", n)
+# end
+
 
 nothing

--- a/examples/ram_air_kite_loop.jl
+++ b/examples/ram_air_kite_loop.jl
@@ -13,9 +13,9 @@ vsm_interval = 5
 steps = Int(round(total_time / dt))
 
 set = se("system_ram.yaml")
-set.segments = 6
+set.segments = 7
 set_values = [-50, -1.1, -1.1]
-set.quasi_static = false
+set.quasi_static = true
 
 if !@isdefined s
     wing = RamAirWing(set)

--- a/src/mtk_model.jl
+++ b/src/mtk_model.jl
@@ -250,7 +250,7 @@ function force_eqs!(s, system, eqs, defaults, guesses;
         
         inertia = 1/3 * (s.set.mass/length(groups)) * (norm(group.chord))^2 # plate inertia around leading edge
         @assert !(inertia ≈ 0.0)
-        @parameters twist_damp = s.set.quasi_static ? 200 : 50
+        @parameters twist_damp = s.set.quasi_static ? 200 : 100
         eqs = [
             eqs
             group_tether_moment[group.idx] ~ sum(tether_moment[group.idx, :])
@@ -505,7 +505,7 @@ function diff_eqs!(s, eqs, defaults; tether_kite_force, tether_kite_moment, aero
         total_tether_kite_force(t)[1:3]
         total_tether_kite_moment(t)[1:3]
     end
-    @parameters ω_damp = s.set.quasi_static ? 100 : 0
+    @parameters ω_damp = 150
 
     Ω = [0       -ω_b[1]  -ω_b[2]  -ω_b[3];
         ω_b[1]    0        ω_b[3]  -ω_b[2];

--- a/src/point_mass_system.jl
+++ b/src/point_mass_system.jl
@@ -22,6 +22,8 @@ function PointMassSystem(set::Settings, wing::RamAirWing)
     bridle_top_left = [wing.R_cad_body * (set.top_bridle_points[i] + wing.T_cad_body) for i in eachindex(set.top_bridle_points)] # cad to kite frame
     bridle_top_right = [bridle_top_left[i] .* [1, -1, 1] for i in eachindex(set.top_bridle_points)]
 
+    dynamics_type = set.quasi_static ? STATIC : DYNAMIC
+
     function create_bridle(bridle_top, gammas)
         i_pnt = length(points) # last point idx
         i_seg = length(segments) # last segment idx
@@ -47,18 +49,18 @@ function PointMassSystem(set::Settings, wing::RamAirWing)
 
         points = [
             points
-            Point(9+i_pnt, bridle_top[1], DYNAMIC)
-            Point(10+i_pnt, bridle_top[2], DYNAMIC)
-            Point(11+i_pnt, bridle_top[3], DYNAMIC)
-            Point(12+i_pnt, bridle_top[4], DYNAMIC)
+            Point(9+i_pnt, bridle_top[1], dynamics_type)
+            Point(10+i_pnt, bridle_top[2], dynamics_type)
+            Point(11+i_pnt, bridle_top[3], dynamics_type)
+            Point(12+i_pnt, bridle_top[4], dynamics_type)
 
-            Point(13+i_pnt, bridle_top[2] .+ [0, 0, -1], DYNAMIC)
+            Point(13+i_pnt, bridle_top[2] .+ [0, 0, -1], dynamics_type)
 
-            Point(14+i_pnt, bridle_top[1] .+ [0, 0, -2], DYNAMIC)
-            Point(15+i_pnt, bridle_top[3] .+ [0, 0, -2], DYNAMIC)
+            Point(14+i_pnt, bridle_top[1] .+ [0, 0, -2], dynamics_type)
+            Point(15+i_pnt, bridle_top[3] .+ [0, 0, -2], dynamics_type)
 
-            Point(16+i_pnt, bridle_top[1] .+ [0, 0, -3], DYNAMIC)
-            Point(17+i_pnt, bridle_top[3] .+ [0, 0, -3], DYNAMIC)
+            Point(16+i_pnt, bridle_top[1] .+ [0, 0, -3], dynamics_type)
+            Point(17+i_pnt, bridle_top[3] .+ [0, 0, -3], dynamics_type)
         ]
         l1 = norm(points[9+i_pnt].pos_b - points[1+i_pnt].pos_b)
         l2 = norm(points[9+i_pnt].pos_b - points[5+i_pnt].pos_b)
@@ -88,8 +90,8 @@ function PointMassSystem(set::Settings, wing::RamAirWing)
         ]
         pulleys = [
             pulleys
-            Pulley(1+i_pul, (13+i_seg, 14+i_seg), DYNAMIC)
-            Pulley(2+i_pul, (16+i_seg, 17+i_seg), DYNAMIC)
+            Pulley(1+i_pul, (13+i_seg, 14+i_seg), dynamics_type)
+            Pulley(2+i_pul, (16+i_seg, 17+i_seg), dynamics_type)
         ]
         push!(attach_points, points[end-1])
         push!(attach_points, points[end])
@@ -107,13 +109,13 @@ function PointMassSystem(set::Settings, wing::RamAirWing)
             i_pnt = length(points) # last point idx
             i_seg = length(segments) # last segment idx
             if i == 1
-                points = [points; Point(1+i_pnt, pos, DYNAMIC)]
+                points = [points; Point(1+i_pnt, pos, dynamics_type)]
                 segments = [segments; Segment(1+i_seg, (attach_point.idx, 1+i_pnt), type)]
             elseif i == set.segments
                 points = [points; Point(1+i_pnt, pos, WINCH)]
                 segments = [segments; Segment(1+i_seg, (i_pnt, 1+i_pnt), type)]
             else
-                points = [points; Point(1+i_pnt, pos, DYNAMIC)]
+                points = [points; Point(1+i_pnt, pos, dynamics_type)]
                 segments = [segments; Segment(1+i_seg, (i_pnt, 1+i_pnt), type)]
             end
             push!(segment_idxs, 1+i_seg)

--- a/src/ram_air_kite.jl
+++ b/src/ram_air_kite.jl
@@ -400,7 +400,7 @@ function init_sim!(s::RamAirKite, measure::Measurement; prn=true)
     return nothing
 end
 
-function init_sim!(s::RamAirKite; prn=true)
+function init_sim!(::RamAirKite; prn=true)
     throw(ArgumentError("Use the function init_sim!(s::RamAirKite, measure::Measurement) instead."))
 end
 

--- a/src/ram_air_kite.jl
+++ b/src/ram_air_kite.jl
@@ -448,9 +448,8 @@ function reinit!(s::RamAirKite, measure::Measurement; prn=true, reload=false)
             s.prob = deserialize(prob_path)
             s.sys = s.prob.f.sys
             s.integrator = OrdinaryDiffEqCore.init(s.prob, solver; dt, abstol=s.set.abs_tol, reltol=s.set.rel_tol, save_on=false, save_everystep=false)
-            sym_vec = zeros(Num, length(s.integrator.u))
-            s.unknowns_vec = zeros(SimFloat, length(s.integrator.u))
             sym_vec = get_unknowns(s)
+            s.unknowns_vec = zeros(SimFloat, length(sym_vec))
             generate_getters!(s, sym_vec)
         end
         prn && @info "Loaded problem from $prob_path and initialized integrator in $t seconds"

--- a/test/test_ram_air_kite.jl
+++ b/test/test_ram_air_kite.jl
@@ -225,7 +225,7 @@ const BUILD_SYS = true
             right_heading_diff = angle_diff(sys_state_right.heading, sys_state_initial.heading)
             @test right_heading_diff > 0.6
             left_heading_diff = angle_diff(sys_state_left.heading, sys_state_initial.heading)
-            @test left_heading_diff < -0.6
+            @test left_heading_diff < -0.5
             @test abs(right_heading_diff) ≈ abs(left_heading_diff) atol=0.3
         end
     end


### PR DESCRIPTION
Add an option in settings for a quasi-static model, where the tether points and the pulleys will be modeled with `acc = 0`.
Also fix the damping values so that they work for both the quasi static model, and a 6-segment tether.