### PR TITLE
Update CLAUDE.md/CONTRIBUTING.md and add the vertical wind plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,8 +34,9 @@ Both `KPS3` and `KPS4` are mutable structs parameterized as `{S, T, P, Q, SP}` (
 type, #points, #springs, spring type) and subtype `AbstractKiteModel` (defined in `KiteUtils`).
 `src/KiteModels.jl` is the top-level module: it declares shared constants/type aliases, re-exports
 `KitePodModels`, `WinchModels`, `AtmosphericModels` (via `@reexport`), and `include`s `KPS4.jl`,
-`KPS3.jl`, `utils.jl` in that order — there's no separate build step, editing a `src/*.jl` file and
-reloading (Revise) is enough.
+`KPS3.jl`, `utils.jl` in that order (plus `precompile.jl` at the very end, which holds the
+`@compile_workload`) — there's no separate build step, editing a `src/*.jl` file and reloading
+(Revise) is enough.
 
 Shared type aliases (`src/KiteModels.jl`): `SimFloat = Float64` for all sim scalars, `KVec3 =
 MVector{3,SimFloat}` (mutable, stack-allocated), `SVec3 = SVector{3,SimFloat}` (immutable).
@@ -60,6 +61,19 @@ All physical/numerical parameters live in YAML under `data/` (`settings.yaml`, `
 versioned variants like `settings_v9b.yaml`). Key sections: `system` (segments, sample_freq,
 sim_time), `solver` (abs_tol, rel_tol, IDA vs DFBDF), `kite`/`kps4` (mass, area, aero coefficients),
 `tether` (d_tether, e_tether, damping). `Settings` objects come from `KiteUtils`, not this package.
+
+### Wind and turbulence
+
+Wind lives in `AtmosphericModels`, not here. `set_v_wind_ground!` (`src/KiteModels.jl`, called from
+`next_step!`) branches on `set.use_turbulence`: at `0` it uses `calc_wind_factor(s.am, height)` for
+the kite and `height / 2` for the tether; otherwise it delegates to
+`calc_turbulent_wind(s.am, pos, s.t_0; upwind_dir)`, which was moved out to `AtmosphericModels` in
+Feb 2026 — don't look for the turbulence math in this repo.
+
+`get_default_turbulence()` / `set_default_turbulence(x)` are a separate, GUI-facing concern: they
+read and rewrite `gui.default_turbulence` in `data/gui.yaml` (created from `gui.yaml.default` when
+missing), which is what supplies `use_turbulence` to a project's settings. Covered by
+`test/test-default_turbulence.jl`.
 
 ### Coordinate system
 
@@ -99,6 +113,11 @@ This is a Julia package developed with a workspace: `Project.toml` declares
   ```julia
   using Pkg; Pkg.activate("docs"); include("docs/make.jl"); Pkg.activate(".")
   ```
+  `bin/build_docu` is something else: it renders only `docs/src/open_source_awe.md` (the
+  mathematical background) to PDF via `pandoc`, and needs `pandoc` installed.
+- **Cut a release**: `./bin/release` (`--dry-run` first). It takes the top section of `CHANGELOG.md`
+  as release notes and posts `@JuliaRegistrator register` on GitHub issue #9 via `gh`; it refuses to
+  run unless the working tree is clean and the branch is pushed. See the release checklist below.
 - **Formatting**: `.JuliaFormatter.toml` sets `indent = 4`, `margin = 92`. Format via JuliaFormatter,
   not by hand-editing whitespace.
 - **License linting**: `bin/reuse_lint` runs `pipx run reuse lint` (every file must carry an
@@ -116,13 +135,14 @@ This is a Julia package developed with a workspace: `Project.toml` declares
   `mass_tether_particle[i-1]`.
 - Align `=`/equation signs vertically across related lines for readability.
 - Install `Revise` into the **global** Julia environment, never as a project dependency.
-- To load settings ad hoc in a script, use `se("system_3l.yaml")` (loads relative to the active
-  project's `data/` dir).
+- To load settings ad hoc in a script, use `se("system.yaml")` (loads relative to the active
+  project's `data/` dir). Note `docs/src/advanced.md` still shows `se("system_3l.yaml")` in this
+  spot — that file was removed along with the 3-line model, so don't copy the name from there.
 
 ## Release checklist (from CONTRIBUTING.md)
 
 Before cutting a release: all tests pass; every example is reachable from the menu and runs; diff
-`create_sys_image2.jl` against `create_sys_image.jl` with `meld`; verify
-`test_installation`/`test_installation2`/`test_installation3` scripts work; diff `README.md` against
-`docs/src/index.md` with `meld` and reconcile; test install on Linux (both supported Julia versions)
-and on Windows with a fresh `.julia` folder; run `bin/reuse_lint`.
+`create_sys_image2.jl` against `create_sys_image.jl` with `meld`; verify the `test/test_installation`
+… `test_installation5` scripts work; diff `README.md` against `docs/src/index.md` with `meld` and
+reconcile; test install on Linux (every Julia version in the `julia` compat entry of `Project.toml`)
+and on Windows with a fresh `.julia` folder; run `bin/reuse_lint`. Then `./bin/release`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,10 +98,13 @@ Before creating a new release, please check
 - update `create_sys_image2.jl` by comparing it with `create_sys_image.jl` using `meld`
 - make sure that the scripts
   - test_installation
-  - test_installation2 and
-  - test_installation3 work
+  - test_installation2
+  - test_installation3
+  - test_installation4 and
+  - test_installation5 work
 - execute `meld README.md docs/src/index.md` and make sure both are up-to-date
-- test the installation on Linux for both Julia 1.10 and the latest stable Julia version
+- test the installation on Linux for all Julia versions listed in the `julia` compat entry of
+  `Project.toml` (currently 1.11 and 1.12)
 - test the installation on Windows after deleting the .julia folder
 - run `pipx run reuse lint` and make sure all files have a license attached;
   See: <https://reuse.readthedocs.io/en/latest/readme.html>

--- a/PlanVerticalWind.md
+++ b/PlanVerticalWind.md
@@ -1,0 +1,134 @@
+<!--
+SPDX-FileCopyrightText: 2026 Uwe Fechner
+SPDX-License-Identifier: MIT
+-->
+
+# Implement feature: vertical wind
+
+## Goal
+
+Allow a vertical wind component (updraft/downdraft) at the kite, so that the apparent wind gets a
+nonzero z-velocity. Fully backward compatible: the default of `0.0` reproduces today's behavior
+exactly.
+
+## Original request
+
+> I'm using KiteModels (v0.6.17, via a Python/Julia setup) and I'd like to inject a vertical wind
+> component at the kite — e.g. to simulate updrafts/gusts with a nonzero z-velocity in the apparent
+> wind. Right now `set_v_wind_ground!` forces the vertical component to zero. Would you be open to
+> adding an optional keyword (default 0.0) that sets the vertical component, plumbed through
+> `next_step!`? It's fully backward-compatible, and since `v_wind_kite` returns `s.v_wind`, the
+> component would also show up in the logged state automatically.
+
+The request is valid: `set_v_wind_ground!` rewrites `s.v_wind` at the start of every `next_step!`
+(`src/KiteModels.jl:695`), so a caller cannot inject the component from outside — an API change is
+required. The report is against v0.6.17; the relevant line still exists verbatim in 0.11.x, but a
+turbulence branch was added above it in the meantime, which changes the implementation (see
+decision 1).
+
+## Design decisions
+
+### 1. Add to, do not overwrite, the vertical component
+
+`set_v_wind_ground!` (`src/KiteModels.jl:220-236`) has two branches. With `use_turbulence > 0` it
+delegates to `AtmosphericModels.calc_turbulent_wind`, and the Mann field is a full three-component
+field — its `w` component is passed straight through, so `s.v_wind[3]` is *already* nonzero there.
+A plain `s.v_wind[3] = v_wind_vert` would therefore silently delete the vertical turbulence.
+
+Use `s.v_wind[3] += v_wind_vert` after the `if`/`else`, so the value is a mean updraft superimposed
+on whatever the wind model already produced. In the laminar branch the third component is zero, so
+`+=` and `=` coincide there.
+
+### 2. Store it in the model struct, don't thread a keyword through every call site
+
+`set_v_wind_ground!` has six call sites — `next_step!` (`src/KiteModels.jl:695`), `init!`
+(`src/KiteModels.jl:623`), `src/KPS3.jl:488`, `src/KPS3.jl:562`, `src/KPS4.jl:713` and
+`src/KPS4.jl:763`. None of them are inside `residual!`, so either approach is technically safe, but
+a keyword on `next_step!` alone would leave all the initialization and steady-state paths at zero
+and require touching five more signatures to change that.
+
+Instead, follow the pattern `next_step!` already uses for `set_speed`/`set_torque`/`bearing`: add a
+defaulted field to both model structs, have `next_step!` write the keyword into it, and let
+`set_v_wind_ground!` read it. Both structs are `@with_kw mutable struct`, so a defaulted field is
+backward compatible.
+
+### 3. Phase 1 is kite-only; the tether stays horizontal
+
+The vertical component is applied to `s.v_wind` (the wind at the kite), not to `v_wind_tether`.
+This is a deliberate, documented limitation, not an oversight:
+
+- **KPS3** would honor a vertical `v_wind_tether`: it is written only in `clear!` (`src/KPS3.jl:154`)
+  and in `set_v_wind_ground!`, and read by `calc_drag` (`src/KPS3.jl:207`).
+- **KPS4** would not. `inner_loop!` recomputes `s.v_wind_tether` per spring from `s.v_wind_gnd`
+  (`src/KPS4.jl:453`, called at `src/KPS4.jl:489`), and `v_wind_gnd` is horizontal by construction
+  (`src/KiteModels.jl:224`). Anything written upstream is discarded. (The same overwrite already
+  discards the *turbulent* tether wind for KPS4 — a pre-existing quirk, out of scope here.)
+
+Applying it to KPS3 only would make the two models disagree. Phase 1 therefore leaves the tether
+alone in both, and documents it. See "Possible phase 2" below.
+
+### 4. Sign convention: positive is up
+
+In this code `z` is up — `calc_height` is `pos_kite(s)[3]` and heights are positive. The NED frame
+mentioned in the docs applies to *orientation*, not to these vectors, which invites the opposite
+reading. The docstrings must state explicitly that a positive `v_wind_vert` is an updraft.
+
+### 5. Leave `v_wind_gnd` horizontal
+
+`upwind_dir(v_wind_gnd)` is an `atan` over components 1 and 2 (`src/KiteModels.jl:238-245`). The
+ground wind vector must keep its `0.0` third component; only `s.v_wind` is touched.
+
+## Implementation steps
+
+1. **`src/KPS4.jl`** — add to the struct, next to `v_wind_tether`:
+   ```julia
+   "vertical wind velocity at the kite, positive up [m/s]"
+   v_wind_vert::S = 0.0
+   ```
+2. **`src/KPS3.jl`** — the same field (note KPS3 is parameterized `{S, T, P}`, KPS4 is
+   `{S, T, P, Q, SP}`; the field only needs `S`). Reset it in `clear!` alongside the other wind
+   fields.
+3. **`src/KiteModels.jl`, `set_v_wind_ground!`** — after the `if`/`else` and before `s.rho = ...`:
+   ```julia
+   s.v_wind[3] += s.v_wind_vert
+   ```
+   Update the docstring: new behavior, sign convention, and the note that the tether wind is
+   unaffected.
+4. **`src/KiteModels.jl`, `next_step!`** — add the keyword `v_wind_vert=0.0` and assign
+   `s.v_wind_vert = v_wind_vert` next to the existing `s.sync_speed = set_speed` assignments, i.e.
+   before the `set_v_wind_ground!` call. Document the keyword in the docstring's parameter list.
+5. **Docs** — mention the keyword where `next_step!` and the wind model are described, and add a
+   `CHANGELOG.md` entry under the next version.
+
+Because the assignment happens once per `next_step!`, the updraft is constant across the step,
+consistent with how `s.v_wind` is already handled.
+
+## What comes for free
+
+`v_wind_kite(s)` returns `s.v_wind` (`src/KiteModels.jl:211`), `update_sys_state!` copies it with
+`ss.v_wind_kite .= s.v_wind` (`src/KiteModels.jl:552`), and KiteUtils logs `v_wind_kite` as a full
+`MVector{3}` (`_logger.jl:58`, `_log.jl:48`). The vertical component therefore appears in the system
+state and in saved logs with no further work — the original request is right about this.
+
+The aerodynamics also pick it up directly: the kite-point apparent wind is `s.v_wind - v_*` at
+`src/KPS4.jl:369` and `src/KPS3.jl:220`.
+
+## Tests
+
+Add to `test/test-kps4.jl` (and a KPS3 equivalent in `test/test-kps3.jl`):
+
+1. Default `v_wind_vert` is `0.0` and `s.v_wind[3] == 0.0` — the backward-compatibility guarantee.
+2. With `v_wind_vert = 1.0` and `use_turbulence == 0`, `s.v_wind[3] ≈ 1.0` after `next_step!`, and
+   the horizontal components are unchanged.
+3. **Regression for decision 1**: with `use_turbulence > 0`, `s.v_wind[3]` equals the turbulent
+   vertical component *plus* `v_wind_vert`, not `v_wind_vert` alone.
+4. `s.v_wind_gnd[3] == 0.0` and `upwind_dir(s)` is unaffected.
+5. A short simulation with a nonzero updraft stays finite and the logged `v_wind_kite[3]` carries
+   the value.
+
+## Possible phase 2 (not in scope)
+
+Extend the vertical component to the tether: set it in `v_wind_tether` for KPS3, and for KPS4 pass
+it into `inner_loop!` so it survives the per-spring recomputation. Worth doing only if a use case
+needs updrafts large enough to matter for tether drag; it also invites fixing the related quirk that
+KPS4 discards the turbulent tether wind.

--- a/data/settings.yaml
+++ b/data/settings.yaml
@@ -135,7 +135,7 @@ environment:
     rho_0:  1.225            # air density at zero height and 15 °C    [kg/m³]
     alpha:  0.08163          # exponent of the wind profile law
     z0:     0.0002           # surface roughness                       [m]
-    profile_law: 3           # 1=EXP, 2=LOG, 3=EXPLOG
+    profile_law: 3           # 0=CONST, 1=EXP, 2=LOG, 3=EXPLOG
     # the following parameters are for calculating the turbulent wind field using the Mann model
     use_turbulence: 0.0      # turbulence intensity relative to Cabauw, NL
     v_wind_gnds: [3.483, 5.324, 8.163] # wind speeds at ref height for calculating the turbulent wind field [m/s]


### PR DESCRIPTION
## Related issues

There is no related issue — documentation only, plus a plan for a feature request.

## What this changes

Documentation and one comment fix. No code is touched, so runtime behaviour is unchanged.

- **`CLAUDE.md`** — brought in line with the current tree:
  - `se("system_3l.yaml")` replaced with `se("system.yaml")`; that file no longer exists.
    `docs/src/advanced.md` still names it, so the entry now warns about that.
  - the include list mentions `src/precompile.jl`.
  - added `bin/release`, and clarified that `bin/build_docu` only renders
    `docs/src/open_source_awe.md` to PDF via pandoc — it is not the Documenter build.
  - new "Wind and turbulence" section: the `set_v_wind_ground!` branch on `use_turbulence`,
    `calc_turbulent_wind` now living in `AtmosphericModels`, and the separate `gui.yaml`-backed
    `get_default_turbulence` / `set_default_turbulence`.
  - the release checklist now lists `test_installation` … `test_installation5` and points at the
    `julia` compat entry instead of a fixed version.
- **`CONTRIBUTING.md`** — the release checklist listed only `test_installation` 1–3 while `test/`
  has 5, and asked for Julia 1.10 while `Project.toml` compat is `1.11, 1.12`.
- **`data/settings.yaml`** — the `profile_law` comment omitted `0=CONST`.
- **`PlanVerticalWind.md`** — an implementation plan for the vertical wind request (injecting an
  updraft/downdraft into the apparent wind at the kite). This is a plan for review, not an
  implementation; nothing in `src/` changes in this PR.

## Notes on the plan

Reviewing the original request against the current code turned up three things the plan corrects:

- `s.v_wind[3] = v_wind_vert` would clobber the Mann field's vertical turbulence component, which
  is nonzero whenever `use_turbulence > 0`. It has to be `+=`.
- A keyword on `next_step!` alone leaves the five other `set_v_wind_ground!` call sites at zero;
  the plan uses a struct field instead, matching how `set_speed` / `set_torque` are handled.
- The tether cannot see the vertical component in KPS4, because `inner_loop!` recomputes
  `s.v_wind_tether` per spring from the horizontal `v_wind_gnd`. Phase 1 is therefore kite-only
  and says so, rather than making KPS3 and KPS4 disagree.

## Checklist

- [x] Tests are passing — no code changed; `src/`, `Project.toml` and `test/` are identical to `main`
- [x] JETLS is not reporting any warnings — no Julia sources changed
- [x] Docs were updated and the script `scripts/build_docu.jl` succeeds — no files under `docs/` changed

`bin/reuse_lint` passes: 175/175 files carry copyright and license information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
